### PR TITLE
Set MIN and MAX FreeBSD version to 13.4 and 14.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ __Note: Use the link (http://k.itty.cat/7) to always get the latest version of t
 
 #### Disclaimers and Warnings
 
-* It makes use of a custom package repository (https://pkg.ny-us.morante.net/desktop/). 
+* It makes use of a custom package repository (http://pkg.morante.net/desktop/). 
 * The [`security/ca_root_nss`](https://www.freshports.org/security/ca_root_nss) package is altered to include the [TDMC/Pacy World, LLC. root CA](http://www.pacyworld.com/ca.php).
 * The [`security/nss`](https://www.freshports.org/security/nss) package is altered to include the [TDMC/Pacy World, LLC. root CA](http://www.pacyworld.com/ca.php).
 * The [`www/firefox`](https://www.freshports.org/www/firefox) and [`www/firefox-esr`](https://www.freshports.org/www/firefox-esr) packages are altered to include the [TDMC/Pacy World, LLC. root CA](http://www.pacyworld.com/ca.php).
@@ -21,7 +21,7 @@ __Note: Use the link (http://k.itty.cat/7) to always get the latest version of t
 
 ## Quick Start
 
-It's recommended that you start with a clean install of FreeBSD 14.x 64-bit.  Your non-root user
+It's recommended that you start with a clean install of FreeBSD 14.1 64-bit.  Your non-root user
 should belong to the `video`, `operator` and `wheel` group so that it can perform administrative functions.
 
 ```
@@ -48,12 +48,12 @@ There is no error control.  If a package fails to download, the execution will j
 
 Platform options are limited only due to lack of packages.  It's recomended that you start with a fresh copy of FreeBSD for the best results.
 
-- FreeBSD 13.2-RELEASE or later
+- FreeBSD 13.3-RELEASE or later
 - 64-bit edition (amd64)
 - 20 GB free space
 - Internet connection
 
-Packages for 12.x-RELEASE, 11.x-RELEASE and ARM platforms are also built, but not guaranteed to be available.
+Packages for ARM platforms are also built but not guaranteed to be available.  Older platforms like 12.x-RELEASE and 11.x-RELEASE may or may not work depending on package availability.
 
 ### User
 

--- a/setup.sh
+++ b/setup.sh
@@ -2,7 +2,7 @@
 
 # http://k.itty.cat/7
 # FreeBSD Desktop
-# Version 0.1.33
+# Version 0.1.34
 
 ########################################################################################
 # Copyright (c) 2016-2024, The Daniel Morante Company, Inc.
@@ -38,9 +38,9 @@
 # For a full explination of what is going on here, please visit:
 # 	http://www.unibia.com/unibianet/freebsd/mate-desktop
 
-# For 12.3-RELEASE thru 14.0-RELEASE
-MIN_VERSION=1203000
-MAX_VERSION=1400097
+# For 13.4-RELEASE thru 14.1-RELEASE
+MIN_VERSION=1304000
+MAX_VERSION=1401000
 
 # Setup desktop FreeBSD (the "-K" option for "uname" is not avaiable pre-12)
 CURRENT_FREEBSD_VERSION=$(sysctl -n kern.osreldate)


### PR DESCRIPTION
Drop support for anything less than 13.4 and add support for 14.1.  It's been several years since packages for 12.x and 11.x have been built.